### PR TITLE
fix: fonts path and add local()

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -8,24 +8,26 @@ export default css`
 
   @font-face {
     font-family: "Avenir";
-    src: url("Avenir-Roman.eot");
-    src: url("Avenir-Roman.eot?#iefix") format("embedded-opentype"),
-      url("Avenir-Roman.woff2") format("woff2"),
-      url("Avenir-Roman.woff") format("woff"),
-      url("Avenir-Roman.ttf") format("truetype"),
-      url("Avenir-Roman.svg#Avenir-Roman") format("svg");
+    src: local("Avenir-Roman"), url("/fonts/Avenir-Roman.eot");
+    src: local("Avenir-Roman"),
+      url("/fonts/Avenir-Roman.eot?#iefix") format("embedded-opentype"),
+      url("/fonts/Avenir-Roman.woff2") format("woff2"),
+      url("/fonts/Avenir-Roman.woff") format("woff"),
+      url("/fonts/Avenir-Roman.ttf") format("truetype"),
+      url("/fonts/Avenir-Roman.svg#Avenir-Roman") format("svg");
     font-weight: normal;
     font-style: normal;
   }
 
   @font-face {
     font-family: "Avenir";
-    src: url("Avenir-Black.eot");
-    src: url("Avenir-Black.eot?#iefix") format("embedded-opentype"),
-      url("Avenir-Black.woff2") format("woff2"),
-      url("Avenir-Black.woff") format("woff"),
-      url("Avenir-Black.ttf") format("truetype"),
-      url("Avenir-Black.svg#Avenir-Black") format("svg");
+    src: local("Avenir-Black"), url("/fonts/Avenir-Black.eot");
+    src: local("Avenir-Black"),
+      url("/fonts/Avenir-Black.eot?#iefix") format("embedded-opentype"),
+      url("/fonts/Avenir-Black.woff2") format("woff2"),
+      url("/fonts/Avenir-Black.woff") format("woff"),
+      url("/fonts/Avenir-Black.ttf") format("truetype"),
+      url("/fonts/Avenir-Black.svg#Avenir-Black") format("svg");
     font-weight: 900;
     font-style: normal;
   }


### PR DESCRIPTION
**Description**
- fix font (in FireFox)

**Summary of Changes**
- change font paths and add `local()` in `global.js`

**How to Test**
- check if font is displaying correctly in FireFox and Chrome

**Screenshots**
![image](https://user-images.githubusercontent.com/25174423/64504054-6b968c80-d300-11e9-869f-843681892cf6.png)
