### PR TITLE
Create Root Element for Gatsby Browser / SSR

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,25 +1,6 @@
-/**
- * Implement Gatsby's Browser APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/browser-apis/
- */
-
-// You can delete this file if you're not using it
-
 import React from "react"
-import { ThemeProvider } from "emotion-theming"
-import { Global } from "@emotion/core"
-import { Box } from "rebass"
+import RootElement from "./src/root-element"
 
-import theme from "./src/theme"
-import globalStyles from "./src/global"
-
-// eslint-disable-next-line import/prefer-default-export
 export const wrapRootElement = ({ element }) => (
-  <>
-    <ThemeProvider theme={theme}>
-      <Global styles={globalStyles} />
-      <Box variant="styles.root">{element}</Box>
-    </ThemeProvider>
-  </>
+  <RootElement>{element}</RootElement>
 )

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,7 +1,7 @@
-/**
- * Implement Gatsby's SSR (Server Side Rendering) APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/ssr-apis/
- */
+import React from "react"
+import RootElement from "./src/root-element"
 
-// You can delete this file if you're not using it
+// eslint-disable-next-line import/prefer-default-export
+export const wrapRootElement = ({ element }) => (
+  <RootElement>{element}</RootElement>
+)

--- a/src/root-element.js
+++ b/src/root-element.js
@@ -1,0 +1,23 @@
+import React from "react"
+import { ThemeProvider } from "emotion-theming"
+import { Global } from "@emotion/core"
+import PropTypes from "prop-types"
+import { Box } from "rebass"
+
+import theme from "./theme"
+import globalStyles from "./global"
+
+const RootElement = ({ children }) => (
+  <>
+    <ThemeProvider theme={theme}>
+      <Global styles={globalStyles} />
+      <Box variant="styles.root">{children}</Box>
+    </ThemeProvider>
+  </>
+)
+
+RootElement.propTypes = {
+    children: PropTypes.node.isRequired,
+}
+
+export default RootElement


### PR DESCRIPTION
**Description**
It's a common pattern that whatever is present in gatsby-browser should be present in gatsby-ssr. 
I created a root element to share the code between the two exposed apis.

**Summary of Changes**
- Added root element
- Added definition in `gatsby-ssr.js`
- Edited `gatsby-browser.js`

**How to Test**
- `yarn start` should produce the site normally.
