### PR TITLE
Fix hero bg size

### DIFF
--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -6,7 +6,10 @@ import Container from "./container"
 
 const heroStyle = css`
     position: relative;
-    background: url("${heroImg}") no-repeat center;
+    background-image: url("${heroImg}");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
     width: 100%;
     height: 65rem;
 `
@@ -84,7 +87,10 @@ const Hero = () => (
         backgroundColor: theme.colors.darkBlue,
         width: "100%",
         height: "100%",
-        background: `url("${heroImg}") no-repeat center`,
+        backgroundImage: `url("${heroImg}")`,
+        backgroundRepeat: "no-repeat",
+        backgroundPosition: "center",
+        backgroundSize: "cover",
         WebkitMaskImage: `url("${heroBrandmark}")`,
         WebkitMaskRepeat: "no-repeat",
         WebkitMaskPosition: "right",


### PR DESCRIPTION
**Summary of Changes**
- Fix hero bg and mask size to cover the whole area.

**Screenshots**
before:
<img width="1677" alt="Screen Shot 2019-10-14 at 5 18 48 PM" src="https://user-images.githubusercontent.com/26339364/66740876-d4949580-eea6-11e9-9498-c542c7cb5fa4.png">

after:
<img width="1677" alt="Screen Shot 2019-10-14 at 5 18 13 PM" src="https://user-images.githubusercontent.com/26339364/66740962-f8f07200-eea6-11e9-8e22-9682696f2c55.png">

