### PR TITLE
feat: 💄 mobile responsive [except header]

### DIFF
--- a/src/components/contact.js
+++ b/src/components/contact.js
@@ -8,7 +8,7 @@ const Contact = () => (
   <Box backgroundColor="darkBlue" py={4}>
     <Container>
       <Text
-        fontSize={6}
+        fontSize={[4, 5]}
         fontWeight="bold"
         color="lightBlue"
         mb={3}
@@ -28,20 +28,20 @@ const Contact = () => (
         <Box
           sx={{
             display: "grid",
-            gridTemplateColumns: "repeat(3, 1fr)",
-            gridTemplateRows: "auto 1fr",
+            gridTemplateColumns: ["auto", `repeat(3, 1fr)`],
+            gridTemplateRows: ["1fr", "auto 1fr"],
             gridColumnGap: "2rem",
             gridRowGap: "2rem",
           }}
           mb={2}
         >
-          <Box sx={{ gridArea: "1 / 1 / 2 / 2" }}>
+          <Box sx={{ gridArea: ["auto", "1 / 1 / 2 / 2"] }}>
             <FormInput name="Name" label="Name" type="text" />
           </Box>
-          <Box sx={{ gridArea: "2 / 1 / 3 / 2" }}>
+          <Box sx={{ gridArea: ["auto", "2 / 1 / 3 / 2"] }}>
             <FormInput name="Email" label="Email" type="text" />
           </Box>
-          <Box sx={{ gridArea: "1 / 2 / 3 / 4" }}>
+          <Box sx={{ gridArea: ["auto", " 1 / 2 / 3 / 4"] }}>
             <FormInput name="Message" label="Message" type="textarea" />
           </Box>
         </Box>

--- a/src/components/container.js
+++ b/src/components/container.js
@@ -3,7 +3,7 @@ import { Box } from "rebass"
 import PropTypes from "prop-types"
 
 const Container = ({ children }) => (
-  <Box width="100%" maxWidth={1260} mx="auto" px={3}>
+  <Box width="100%" maxWidth={1260} mx="auto" px={[2, 3]}>
     {children}
   </Box>
 )

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -35,12 +35,25 @@ const Footer = () => (
           color: "white",
           display: "grid",
           gridTemplateColumns: "1fr auto 1fr",
-          gridTemplateRows: "1fr 1fr",
-          gridTemplateAreas: `"TopLeft Logo TopRight" "BottomLeft Logo BottomRight"`,
+          gridTemplateRows: ["auto", "1fr 1fr"],
+          gridTemplateAreas: [
+            `"TopLeft Logo TopRight"
+            "BottomRight BottomRight BottomRight"
+            "BottomLeft BottomLeft BottomLeft"`,
+
+            `"TopLeft Logo TopRight"
+            "BottomLeft Logo BottomRight"`,
+          ],
         }}
       >
-        <Box sx={{ gridArea: "TopLeft", borderBottom: "2px solid #505D90" }} />
-        <Box sx={{ gridArea: "TopRight", borderBottom: "2px solid #505D90" }} />
+        <Box
+          mb={[3, 0]}
+          sx={{ gridArea: "TopLeft", borderBottom: "2px solid #505D90" }}
+        />
+        <Box
+          mb={[3, 0]}
+          sx={{ gridArea: "TopRight", borderBottom: "2px solid #505D90" }}
+        />
         <Box sx={{ gridArea: "BottomLeft" }}>
           <FooterContentLeft />
         </Box>
@@ -56,15 +69,19 @@ const Footer = () => (
 )
 
 const FooterBrandLogo = () => (
-  <Box px={3} textAlign="center">
+  <Box px={[2, 3]} textAlign="center">
     <GatsbyLink to="/">
-      <Image src={Logo} alt="React JS Philippines" width="10.88rem" />
+      <Image
+        src={Logo}
+        alt="React JS Philippines"
+        width={["6rem", "10.88rem"]}
+      />
     </GatsbyLink>
   </Box>
 )
 
 const FooterContentLeft = () => (
-  <Box mt={2}>
+  <Box mt={2} textAlign={["center", "left"]}>
     <Text fontSize={1}>
       {`Designed by `}
       <Link href={designerLink} color="white">
@@ -85,11 +102,18 @@ const FooterContentRight = () => {
   } = useStaticQuery(FooterQuery)
 
   return (
-    <Flex flex={1} justifyContent="flex-end" alignItems="center" mt={2}>
+    <Flex
+      flex={1}
+      justifyContent="flex-end"
+      alignItems="center"
+      mt={2}
+      flexDirection={["column", "row"]}
+    >
       <Text
         fontSize={2}
         fontWeight="bold"
-        mr={2}
+        mr={[0, 2]}
+        mb={[2, 0]}
         sx={{ textTransform: "uppercase" }}
       >
         Join the community

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -12,7 +12,7 @@ const Hero = () => (
       backgroundPosition: "center",
       backgroundSize: "cover",
       width: "100%",
-      height: "120vh",
+      height: ["100vh", "120vh"],
     }}
   >
     <Box
@@ -31,7 +31,7 @@ const Hero = () => (
       alignItems="center"
       css={{
         position: "absolute",
-        top: "-5vh",
+        top: [0, "-5vh"],
         left: 0,
         width: "100%",
         height: "100%",
@@ -40,21 +40,41 @@ const Hero = () => (
       }}
     >
       <Container>
-        <Text fontSize={5} color="gold" fontWeight="body" zIndex={2}>
-          ★★★ ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+        <Text
+          fontSize={[4, 5]}
+          color="gold"
+          fontWeight="body"
+          zIndex={2}
+          mb={1}
+          sx={{
+            position: "relative",
+            ":after": {
+              content: "''",
+              position: "absolute",
+              left: ["150px", "200px"],
+              top: 0,
+              bottom: 0,
+              margin: "auto 0",
+              width: "40%",
+              height: "2px",
+              backgroundColor: "gold",
+            },
+          }}
+        >
+          ★ ★ ★
         </Text>
-        <Text fontSize={6} fontWeight="hero" color="white" zIndex={2}>
+        <Text fontSize={[5, 6]} fontWeight="hero" color="white" zIndex={2}>
           WE ARE
         </Text>
-        <Text fontSize={5} fontWeight="hero" color="lightBlue" zIndex={2}>
+        <Text fontSize={[4, 5]} fontWeight="hero" color="lightBlue" zIndex={2}>
           REACTJS
         </Text>
-        <Text fontSize={5} fontWeight="hero" color="gold" zIndex={2}>
+        <Text fontSize={[4, 5]} fontWeight="hero" color="gold" zIndex={2}>
           PHILIPPINES
         </Text>
         <Button
           sx={{
-            marginTop: 3,
+            marginTop: [2, 3],
             py: 2,
             px: 3,
             outline: 0,

--- a/src/components/meetupSection.js
+++ b/src/components/meetupSection.js
@@ -55,7 +55,7 @@ const MeetupSection = () => (
         }}
       >
         {meetups.map(({ id, logo, title, date, venue, replay }) => (
-          <Flex key={id} flexDirection="column" color="darkblue" px={2} mt={2}>
+          <Flex key={id} flexDirection="column" color="darkblue" mt={2}>
             <Image
               src={logo}
               alt={title}

--- a/src/components/missionSection.js
+++ b/src/components/missionSection.js
@@ -5,12 +5,12 @@ import zigzag from "../images/divider.svg"
 
 const MissionSection = () => (
   <Box backgroundColor="darkBlue" py={4}>
-    <Box maxWidth={792} width="100%" textAlign="center" mx="auto" px={3}>
+    <Box maxWidth={792} width="100%" textAlign="center" mx="auto" px={[2, 3]}>
       <Box mb={2}>
         <StarDivider />
       </Box>
       <Text
-        fontSize={3}
+        fontSize={[2, 3]}
         fontWeight="heading"
         color="gold"
         mb={3}
@@ -19,7 +19,7 @@ const MissionSection = () => (
         Mission
       </Text>
       <Text
-        fontSize={3}
+        fontSize={[2, 3]}
         fontWeight="heading"
         color="white"
         maxWidth={582}

--- a/src/components/team.js
+++ b/src/components/team.js
@@ -67,7 +67,7 @@ const TeamSection = () => (
     <Container>
       <Flex justifyContent="center" alignItems="center">
         <Text
-          fontSize={5}
+          fontSize={[3, 5]}
           fontWeight="bold"
           color="lightBlue"
           sx={{
@@ -79,10 +79,10 @@ const TeamSection = () => (
         <Image
           src={brandmarkLogo}
           alt="ReactJS Philippines"
-          width={["50%", "174px"]}
+          width={["30%", "174px"]}
         />
         <Text
-          fontSize={5}
+          fontSize={[3, 5]}
           fontWeight="bold"
           color="lightBlue"
           sx={{
@@ -104,7 +104,7 @@ const TeamSection = () => (
           sx={{
             position: "absolute",
             width: "100%",
-            top: "28px",
+            top: [0, "28px"],
             left: 0,
             zIndex: 1,
             userSelect: "none",
@@ -116,20 +116,26 @@ const TeamSection = () => (
             position: "relative",
           }}
         >
-          <Flex
+          <Box
             mt={3}
-            flexWrap="wrap"
-            flex={1}
-            justifyContent="center"
-            alignItems="center"
+            pt={[3, 0]}
+            sx={{
+              display: ["flex", "grid"],
+              gridTemplateColumns: [
+                "initial",
+                `repeat(auto-fit, minmax(295px, 1fr))`,
+              ],
+              overflowX: ["scroll", "initial"],
+            }}
           >
             {Members.map(member => (
               <Box
                 key={member.id}
                 px={2}
                 py={3}
-                width={1 / 3}
+                width="100%"
                 sx={{
+                  flexShrink: [0, 1],
                   textAlign: "center",
                   transition: "300ms ease all",
                   "&:hover": {
@@ -168,7 +174,7 @@ const TeamSection = () => (
                 </Text>
               </Box>
             ))}
-          </Flex>
+          </Box>
         </Box>
       </Box>
     </Container>

--- a/src/components/visionSection.js
+++ b/src/components/visionSection.js
@@ -25,12 +25,12 @@ const VisionSection = () => (
       },
     }}
   >
-    <Box maxWidth={792} width="100%" textAlign="center" mx="auto" px={3}>
+    <Box maxWidth={792} width="100%" textAlign="center" mx="auto" px={[2, 3]}>
       <Box mb={2}>
         <StarDivider />
       </Box>
       <Text
-        fontSize={3}
+        fontSize={[2, 3]}
         fontWeight="heading"
         color="gold"
         mb={3}
@@ -39,7 +39,7 @@ const VisionSection = () => (
         Vision
       </Text>
       <Text
-        fontSize={3}
+        fontSize={[2, 3]}
         fontWeight="heading"
         color="darkBlue"
         maxWidth={582}
@@ -55,7 +55,7 @@ const VisionSection = () => (
       <Image src={zigzag} alt="divider" mb={4} />
     </Box>
     <Box
-      height={330}
+      height={[200, 330]}
       width="80%"
       mx="auto"
       sx={{
@@ -67,7 +67,7 @@ const VisionSection = () => (
         boxShadow: "0px 0px 20px 0px rgba(0, 0, 0, 0.50)",
       }}
     />
-    <Box height={165} backgroundColor="darkBlue" mt={-165} />
+    <Box height={[100, 165]} backgroundColor="darkBlue" mt={[-100, -165]} />
   </Box>
 )
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -63,7 +63,7 @@ const customTheme = {
   ],
   variants: {
     nav: {
-      mx: 2,
+      mx: [0, 2],
       fontSize: 1,
       fontWeight: "bold",
       display: "inline-block",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,37 @@
-/* eslint-disable import/prefer-default-export */
+import { useState, useEffect } from "react"
+
 export const generate3dShadow = (size, color) => {
   let result = []
   for (let i = size; i > 0; i -= 1) {
     result = [...result, `${i}px ${i}px ${color}`]
   }
   return result.join()
+}
+
+export const useWindowSize = () => {
+  const isClient = typeof window === "object"
+
+  const getSize = () => ({
+    width: isClient ? window.innerWidth : undefined,
+    height: isClient ? window.innerHeight : undefined,
+  })
+
+  const [windowSize, setWindowSize] = useState(getSize)
+
+  useEffect(() => {
+    if (!isClient) {
+      return false
+    }
+
+    const handleResize = () => {
+      setWindowSize(getSize())
+    }
+
+    window.addEventListener("resize", handleResize)
+
+    return () => window.removeEventListener("resize", handleResize)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return windowSize
 }


### PR DESCRIPTION
**Description**
Make responsive to mobile/small screens

**Summary of Changes**
- add `useWindowSize` hook (to be used in the header)
- add responsive styles in spacing, fonts, grids, and dimension in every section
- the team section will be horizontally scrollable in mobile screens

**How to Test**
Preview it on small screens or mobile

**Screenshots**
![Screenshot_2020-01-30 Home](https://user-images.githubusercontent.com/25174423/73416456-ea43a300-434f-11ea-9247-23f62f160b3f.png)

**Notes**
- Header responsive feature will be in a separate PR

RE: #35 