### PR TITLE
feat: 💄 responsive header and togglable nav in mobile screens

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import PropTypes from "prop-types"
 import { Link as GatsbyLink } from "gatsby"
 import { Box, Image, Flex, Link } from "rebass"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faBars, faTimes } from "@fortawesome/free-solid-svg-icons"
-import { useWindowSize } from "../utils"
+import { useWindowSize, useOnClickOutside } from "../utils"
 import Logo from "../images/logo.svg"
 import Container from "./container"
 
@@ -15,9 +15,14 @@ const menus = [
 ]
 
 const Header = ({ siteTitle }) => {
+  const navRef = useRef()
+
   const size = useWindowSize()
-  const [showMenu, setShowMenu] = useState()
   const isMobile = size.width < 640
+
+  const [showMenu, setShowMenu] = useState()
+
+  useOnClickOutside(navRef, () => setShowMenu(false))
 
   useEffect(() => {
     if (isMobile) {
@@ -32,20 +37,6 @@ const Header = ({ siteTitle }) => {
       document.body.style.overflow = "visible"
     }
   }, [showMenu])
-
-  const handleClickOutsideNav = e => {
-    if (!e.target.closest("#nav-menu") && showMenu) {
-      setShowMenu(false)
-    }
-  }
-
-  useEffect(() => {
-    document.body.addEventListener("click", handleClickOutsideNav)
-
-    return () => {
-      document.body.removeEventListener("click", handleClickOutsideNav)
-    }
-  })
 
   return (
     <Box
@@ -70,7 +61,7 @@ const Header = ({ siteTitle }) => {
             <Image src={Logo} alt={siteTitle} width="12.5rem" />
           </GatsbyLink>
 
-          <Box as="nav" id="nav-menu">
+          <Box as="nav" ref={navRef}>
             <Box
               as="button"
               fontSize={3}

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -16,18 +16,14 @@ const menus = [
 
 const Header = ({ siteTitle }) => {
   const size = useWindowSize()
-  const [isMobile, setIsMobile] = useState()
   const [showMenu, setShowMenu] = useState()
+  const isMobile = size.width < 640
 
   useEffect(() => {
-    if (size.width < 640) {
-      setIsMobile(true)
-      setShowMenu(false)
-    } else {
-      setIsMobile(false)
+    if (isMobile) {
       setShowMenu(false)
     }
-  }, [size])
+  }, [isMobile])
 
   useEffect(() => {
     if (showMenu) {

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,7 +1,10 @@
-import React from "react"
+import React, { useState, useEffect } from "react"
 import PropTypes from "prop-types"
 import { Link as GatsbyLink } from "gatsby"
 import { Box, Image, Flex, Link } from "rebass"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faBars, faTimes } from "@fortawesome/free-solid-svg-icons"
+import { useWindowSize } from "../utils"
 import Logo from "../images/logo.svg"
 import Container from "./container"
 
@@ -11,39 +14,130 @@ const menus = [
   { label: "Jobs", path: "/jobs" },
 ]
 
-const Header = ({ siteTitle }) => (
-  <Box
-    as="header"
-    sx={{
-      backgroundColor: "transparent",
-      position: "absolute",
-      top: 0,
-      left: 0,
-      right: 0,
-      zIndex: 999,
-    }}
-  >
-    <Container>
-      <Flex
-        color="white"
-        justifyContent="space-between"
-        alignItems="center"
-        py={2}
-      >
-        <GatsbyLink to="/">
-          <Image src={Logo} alt={siteTitle} width="12.5rem" />
-        </GatsbyLink>
-        <Box>
-          {menus.map(menu => (
-            <Link key={menu.label} variant="nav" href={menu.path}>
-              {menu.label}
-            </Link>
-          ))}
-        </Box>
-      </Flex>
-    </Container>
-  </Box>
-)
+const Header = ({ siteTitle }) => {
+  const size = useWindowSize()
+  const [isMobile, setIsMobile] = useState()
+  const [showMenu, setShowMenu] = useState()
+
+  useEffect(() => {
+    if (size.width < 640) {
+      setIsMobile(true)
+      setShowMenu(false)
+    } else {
+      setIsMobile(false)
+      setShowMenu(false)
+    }
+  }, [size])
+
+  useEffect(() => {
+    if (showMenu) {
+      document.body.style.overflow = "hidden"
+    } else {
+      document.body.style.overflow = "visible"
+    }
+  }, [showMenu])
+
+  const handleClickOutsideNav = e => {
+    if (!e.target.closest("#nav-menu") && showMenu) {
+      setShowMenu(false)
+    }
+  }
+
+  useEffect(() => {
+    document.body.addEventListener("click", handleClickOutsideNav)
+
+    return () => {
+      document.body.removeEventListener("click", handleClickOutsideNav)
+    }
+  })
+
+  return (
+    <Box
+      as="header"
+      sx={{
+        backgroundColor: "transparent",
+        position: "relative",
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 999,
+      }}
+    >
+      <Container>
+        <Flex
+          color="white"
+          justifyContent="space-between"
+          alignItems="center"
+          py={2}
+        >
+          <GatsbyLink to="/">
+            <Image src={Logo} alt={siteTitle} width="12.5rem" />
+          </GatsbyLink>
+
+          <Box as="nav" id="nav-menu">
+            <Box
+              as="button"
+              fontSize={3}
+              display={isMobile ? "block" : "none"}
+              sx={{
+                backgroundColor: "transparent",
+                color: "white",
+                border: "2px solid transparent",
+                "&:focus, &:active": {
+                  borderColor: "lightBlue",
+                },
+                position: "relative",
+                zIndex: 1,
+              }}
+              onClick={() => setShowMenu(!showMenu)}
+              aria-hidden={!isMobile}
+              aria-label="Toggle nav"
+            >
+              <FontAwesomeIcon
+                aria-hidden="true"
+                icon={!showMenu ? faBars : faTimes}
+              />
+            </Box>
+
+            <Flex
+              flexDirection={["column", "row"]}
+              alignItems="center"
+              justifyContent={["flex-start", "center"]}
+              height={["100vh", "100%"]}
+              backgroundColor={["rgba(0, 0, 0, 0.85)", "initial"]}
+              py={[4, 0]}
+              sx={{
+                transition: "right 300ms ease",
+                ...(isMobile
+                  ? {
+                      position: "absolute",
+                      top: 0,
+                      right: showMenu ? 0 : "-250px",
+                      bottom: 0,
+                      width: "250px",
+                      overflow: "hidden",
+                    }
+                  : {}),
+              }}
+            >
+              {menus.map(menu => (
+                <Link
+                  key={menu.label}
+                  variant="nav"
+                  href={menu.path}
+                  fontSize={[2, "inherit"]}
+                  my={[2, 0]}
+                >
+                  {menu.label}
+                </Link>
+              ))}
+            </Flex>
+          </Box>
+        </Flex>
+      </Container>
+    </Box>
+  )
+}
 
 Header.propTypes = {
   siteTitle: PropTypes.string,

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -7,12 +7,13 @@ const Hero = () => (
   <Box
     sx={{
       position: "relative",
+      top: "-105px",
       backgroundImage: `url("${heroImg}")`,
       backgroundRepeat: "no-repeat",
       backgroundPosition: "center",
       backgroundSize: "cover",
       width: "100%",
-      height: ["100vh", "120vh"],
+      height: "100vh",
     }}
   >
     <Box

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -2,7 +2,6 @@ import React from "react"
 import PropTypes from "prop-types"
 import { StaticQuery, graphql } from "gatsby"
 import { Box } from "rebass"
-
 import Header from "./header"
 import Footer from "./footer"
 
@@ -18,7 +17,11 @@ const Layout = ({ children }) => (
       }
     `}
     render={data => (
-      <Box backgroundColor="darkBlue" minHeight="100vh">
+      <Box
+        backgroundColor="darkBlue"
+        minHeight="100vh"
+        sx={{ overflowX: "hidden" }}
+      >
         <Header siteTitle={data.site.siteMetadata.title} />
         <Box as="main">{children}</Box>
         <Footer />

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,3 +35,21 @@ export const useWindowSize = () => {
 
   return windowSize
 }
+
+export const useOnClickOutside = (ref, handler) => {
+  useEffect(() => {
+    const listener = e => {
+      if (!ref.current || ref.current.contains(e.target)) {
+        return
+      }
+
+      handler(e)
+    }
+
+    document.addEventListener("click", listener)
+
+    return () => {
+      document.removeEventListener("click", listener)
+    }
+  }, [ref, handler])
+}


### PR DESCRIPTION
**Description**
Implement responsive header and togglable nav in mobile screens

**Summary of Changes**
- add overflow-x hidden in the layout container
- implement a responsive header and toggle nav in mobile screens
-  set height of hero to 100vh and offset it to the header

**How to Test**
Preview it on small screens or mobile devices

**Screenshots**
<img src="https://user-images.githubusercontent.com/25174423/73660372-05f1d500-46d3-11ea-9784-1aeb465f3a29.jpg" alt="screenshot mobile version header" width="250px" />

<img src="https://user-images.githubusercontent.com/25174423/73660373-068a6b80-46d3-11ea-8617-fc26658946f8.png" alt="screenshot mobile version header navigation" width="250px" />

Closes #35 