### PR TITLE
fix: 💄 set core team heading's white space to no wrap

### DIFF
--- a/src/components/team.js
+++ b/src/components/team.js
@@ -67,11 +67,12 @@ const TeamSection = () => (
     <Container>
       <Flex justifyContent="center" alignItems="center">
         <Text
-          fontSize={[3, 5]}
+          fontSize={[3, 4]}
           fontWeight="bold"
           color="lightBlue"
           sx={{
             textTransform: "uppercase",
+            whiteSpace: "nowrap",
           }}
         >
           « Core
@@ -82,11 +83,12 @@ const TeamSection = () => (
           width={["30%", "174px"]}
         />
         <Text
-          fontSize={[3, 5]}
+          fontSize={[3, 4]}
           fontWeight="bold"
           color="lightBlue"
           sx={{
             textTransform: "uppercase",
+            whiteSpace: "nowrap",
           }}
         >
           Team »


### PR DESCRIPTION
**Description**
Set core team heading's white space to no-wrap to prevent line break in small screens and reduce its font size based on the design.

**Summary of Changes**
- add `whiteSpace: nowrap` in Core Team heading
- reduce Core Team heading's font size

**How to Test**
Preview it on small screens or mobile devices

**Screenshots**
![Screenshot_2020-02-04 Home](https://user-images.githubusercontent.com/25174423/73750697-9514f080-4798-11ea-99e5-949068b45c4f.png)

