### PR TITLE
fix: 🐛 [UI] fix header on load in small screens or mobile devices

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -95,16 +95,12 @@ const Header = ({ siteTitle }) => {
               py={[4, 0]}
               sx={{
                 transition: "right 300ms ease",
-                ...(isMobile
-                  ? {
-                      position: "absolute",
-                      top: 0,
-                      right: showMenu ? 0 : "-250px",
-                      bottom: 0,
-                      width: "250px",
-                      overflow: "hidden",
-                    }
-                  : {}),
+                position: ["absolute", "static"],
+                top: 0,
+                right: showMenu ? 0 : "-250px",
+                bottom: 0,
+                width: ["250px", "100%"],
+                overflow: ["hidden", "visible"],
               }}
             >
               {menus.map(menu => (

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -51,15 +51,10 @@ const Header = ({ siteTitle }) => {
       }}
     >
       <Container>
-        <Flex
-          color="white"
-          justifyContent="space-between"
-          alignItems="center"
-          py={2}
-        >
-          <GatsbyLink to="/">
+        <Flex color="white" alignItems="center" py={2}>
+          <Link as={GatsbyLink} to="/" sx={{ flexGrow: 1 }}>
             <Image src={Logo} alt={siteTitle} width="12.5rem" />
-          </GatsbyLink>
+          </Link>
 
           <Box as="nav" ref={navRef}>
             <Box
@@ -83,6 +78,7 @@ const Header = ({ siteTitle }) => {
               <FontAwesomeIcon
                 aria-hidden="true"
                 icon={!showMenu ? faBars : faTimes}
+                size="1x"
               />
             </Box>
 

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -65,7 +65,7 @@ const Header = ({ siteTitle }) => {
             <Box
               as="button"
               fontSize={3}
-              display={isMobile ? "block" : "none"}
+              display={["block", "none"]}
               sx={{
                 backgroundColor: "transparent",
                 color: "white",

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -61,6 +61,7 @@ const Header = ({ siteTitle }) => {
               as="button"
               fontSize={3}
               display={["block", "none"]}
+              width="45px"
               sx={{
                 backgroundColor: "transparent",
                 color: "white",


### PR DESCRIPTION
**Description**
Fix header navigation styles on load in small screens or mobile devices

<img src="https://user-images.githubusercontent.com/25174423/73941893-02f02200-4929-11ea-895c-ef64d703810b.jpg" alt="header UI bug" width="250px" />

**Summary of Changes**
- remove ternary styles in navigation and burger menu toggle with `isMobile`
- replace it with default rebass breakpoints
- add size prop in burger menu icon
- add fixed width in button of burger menu icon

**How to Test**
Preview on mobile devices or small screens, and be sure to reload
