### PR TITLE
Fix hero background scaling

### DIFF
--- a/src/components/heroCanvas.js
+++ b/src/components/heroCanvas.js
@@ -37,7 +37,11 @@ const drawRotatingBrandmark = (canvas, heroImageTemplate) => {
 
   const clipPath = new fabric.Path(brandmarkPath)
   clipPath.absolutePositioned = true
-  clipPath.scale((1.2 * canvas.height) / clipPath.height)
+
+  const relativeWidth = 0.8 * canvas.width
+  const ABSOLUTE_MIN_WIDTH = 500
+  const width = Math.max(relativeWidth, ABSOLUTE_MIN_WIDTH)
+  clipPath.scale(width / clipPath.width)
 
   const ANIMATION_TIME = 60 * 1000
   const INITIAL_ANGLE = -15
@@ -63,7 +67,7 @@ const drawRotatingBrandmark = (canvas, heroImageTemplate) => {
     rotatePath(clipPath, clipPathMidpoint, {
       point: new fabric.Point(
         (canvas.width / 4) * 3 - clipPath.getScaledWidth() / 2,
-        -(canvas.height / 4)
+        (0.8 * canvas.height - clipPath.getScaledHeight()) / 2
       ),
       angle,
     })


### PR DESCRIPTION
**Description**
- Scales hero canvas brandmark relative to viewport width

**How to Test**
- Verify that the hero canvas brandmark appears as in the screenshot below

**Screenshots**
> ![image](https://user-images.githubusercontent.com/7394331/75597955-73770280-5ad3-11ea-8b1d-468432979224.png)
> Before

> ![image](https://user-images.githubusercontent.com/7394331/75597950-665a1380-5ad3-11ea-9c3e-55d327696fb5.png)
> After