### PR TITLE
feat: ✨ upcoming and past events in meetup section

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,10 +3,7 @@
     "browser": true
   },
   "extends": ["airbnb", "prettier", "prettier/react"],
-  "plugins": [
-    "prettier",
-    "react-hooks"
-  ],
+  "plugins": ["prettier", "react-hooks"],
   "rules": {
     "react/jsx-filename-extension": [
       1,
@@ -25,7 +22,9 @@
       {
         "exceptions": ["Box"]
       }
-    ]
+    ],
+    "camelcase": "off",
+    "import/prefer-default-export": "off"
   },
   "globals": {
     "window": true,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -52,7 +52,7 @@ module.exports = {
         // Facebook account or page ID
         pageId: FACEBOOK_PAGE_ID,
         params: {
-          fields: ["events.limit(3)"],
+          fields: ["events"],
         },
         // Access Token from Facebook Graph API
         accessToken: process.env.FACEBOOK_GRAPH_TOKEN,

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,7 +1,6 @@
 import React from "react"
 import RootElement from "./src/root-element"
 
-// eslint-disable-next-line import/prefer-default-export
 export const wrapRootElement = ({ element }) => (
   <RootElement>{element}</RootElement>
 )

--- a/src/components/meetupEventCard.js
+++ b/src/components/meetupEventCard.js
@@ -1,9 +1,9 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { Box, Button, Flex, Text } from "rebass"
-import { format } from "date-fns"
+import { format, parseISO } from "date-fns"
 
-const formatDate = date => format(new Date(date.split("T")[0]), "dd MMM yyyy")
+const formatDate = date => format(parseISO(date), "dd MMM yyyy")
 
 const MeetupEventCard = ({ event }) => {
   const { id, name, start_time, place } = event

--- a/src/components/meetupEventCard.js
+++ b/src/components/meetupEventCard.js
@@ -1,0 +1,76 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { Box, Button, Flex, Text } from "rebass"
+import { format } from "date-fns"
+
+const formatDate = date => format(new Date(date.split("T")[0]), "dd MMM yyyy")
+
+const MeetupEventCard = ({ event }) => {
+  const { id, name, start_time, place } = event
+  const city = place?.location?.city
+
+  return (
+    <Flex
+      as="li"
+      bg="white"
+      p={2}
+      mb={2}
+      color="darkBlue"
+      alignItems={["start", null, "center"]}
+      flexDirection={["column", null, "row"]}
+      sx={{
+        cursor: "pointer",
+        transition: "transform 200ms",
+        ":hover": {
+          transform: "translateY(-0.25rem)",
+        },
+      }}
+    >
+      <Box
+        as="time"
+        dateTime={start_time}
+        pr={2}
+        mr={2}
+        fontSize={[1, null, 2]}
+        sx={{
+          textTransform: "uppercase",
+          borderRightWidth: "1px",
+          borderRightStyle: "solid",
+          borderRightColor: ["transparent", null, "darkBlue"],
+        }}
+      >
+        {formatDate(start_time)}
+      </Box>
+
+      <Box flex={1} pt={[1, null, 0]} pb={[2, null, 0]} mr={[0, null, 2]}>
+        <Text
+          as="h4"
+          fontSize={[2, null, 3]}
+          fontWeight="heading"
+          sx={{ textTransform: "uppercase" }}
+        >
+          {name}
+        </Text>
+        <Text>{`${place?.name ?? ""}${city ? `, ${city}` : ""}`}</Text>
+      </Box>
+
+      <Button
+        as="a"
+        href={`https://facebook.com/events/${id}/`}
+        target="_blank"
+        rel="noopener noreferrer"
+        variant="outline"
+        mr="6px"
+        mb="6px"
+      >
+        ↗ Open
+      </Button>
+    </Flex>
+  )
+}
+
+MeetupEventCard.propTypes = {
+  event: PropTypes.instanceOf(Object).isRequired,
+}
+
+export default MeetupEventCard

--- a/src/components/meetupSection.js
+++ b/src/components/meetupSection.js
@@ -1,13 +1,11 @@
-/* eslint-disable camelcase */
 import React from "react"
-import { Box, Button, Flex, Text } from "rebass"
-import { format } from "date-fns"
+import { Box, Button, Text } from "rebass"
+import { isFuture, isPast } from "date-fns"
 import { useStaticQuery, graphql } from "gatsby"
 
 import theme from "../theme"
 import Container from "./container"
-
-const formatDate = date => format(new Date(date.split("T")[0]), "dd MMM yyyy")
+import MeetupEventCard from "./meetupEventCard"
 
 const facebookEventQuery = graphql`
   query FacebookEventQuery {
@@ -35,6 +33,11 @@ const MeetupSection = () => {
       events: { data },
     },
   } = useStaticQuery(facebookEventQuery)
+
+  const upcomingEvents = data.filter(event =>
+    isFuture(new Date(event.start_time))
+  )
+  const pastEvents = data.filter(event => isPast(new Date(event.start_time)))
 
   return (
     <Box pb={[7, 9]}>
@@ -64,74 +67,51 @@ const MeetupSection = () => {
           Community Meet‑ups
         </Text>
 
-        {data.map(({ id, name, start_time, place }) => {
-          const city = place?.location?.city
-
-          return (
-            <Flex
-              key={id}
-              as="li"
-              bg="white"
-              p={2}
+        {upcomingEvents.length >= 1 && (
+          <>
+            <Text
+              as="h3"
+              fontSize={[2, 3]}
+              color="white"
+              fontWeight="heading"
               mb={2}
-              color="darkBlue"
-              alignItems={["start", null, "center"]}
-              flexDirection={["column", null, "row"]}
-              sx={{
-                cursor: "pointer",
-                transition: "transform 200ms",
-                ":hover": {
-                  transform: "translateY(-0.25rem)",
-                },
-              }}
+              sx={{ textTransform: "uppercase" }}
             >
-              <Box
-                as="time"
-                dateTime={start_time}
-                pr={2}
-                mr={2}
-                fontSize={[1, null, 2]}
-                sx={{
-                  textTransform: "uppercase",
-                  borderRightWidth: "1px",
-                  borderRightStyle: "solid",
-                  borderRightColor: ["transparent", null, "darkBlue"],
-                }}
-              >
-                {formatDate(start_time)}
-              </Box>
+              Upcoming
+            </Text>
 
-              <Box
-                flex={1}
-                pt={[1, null, 0]}
-                pb={[2, null, 0]}
-                mr={[0, null, 2]}
-              >
-                <Text
-                  as="h4"
-                  fontSize={[2, null, 3]}
-                  fontWeight="heading"
-                  sx={{ textTransform: "uppercase" }}
-                >
-                  {name}
-                </Text>
-                <Text>{`${place.name}${city ? `, ${city}` : ""}`}</Text>
-              </Box>
+            <Box as="ul">
+              {upcomingEvents.map(event => (
+                <MeetupEventCard key={event.id} event={event} />
+              ))}
+            </Box>
 
-              <Button
-                as="a"
-                href={`https://facebook.com/events/${id}/`}
-                target="_blank"
-                rel="noopener noreferrer"
-                variant="outline"
-                mr="6px"
-                mb="6px"
-              >
-                ↗ Open
-              </Button>
-            </Flex>
-          )
-        })}
+            <Box
+              as="hr"
+              my={3}
+              mx="auto"
+              sx={{ borderColor: "white", height: "2px", maxWidth: "170px" }}
+            />
+
+            <Text
+              as="h3"
+              fontSize={[2, 3]}
+              color="white"
+              fontWeight="heading"
+              mb={2}
+              sx={{ textTransform: "uppercase" }}
+            >
+              Past
+            </Text>
+          </>
+        )}
+
+        <Box as="ul">
+          {/* display only the first three past events */}
+          {pastEvents.splice(0, 3).map(event => (
+            <MeetupEventCard key={event.id} event={event} />
+          ))}
+        </Box>
 
         <Box textAlign="center" mt={3}>
           <Button

--- a/src/components/meetupSection.js
+++ b/src/components/meetupSection.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Box, Button, Text } from "rebass"
-import { isFuture, isPast } from "date-fns"
+import { isFuture, isPast, parseISO } from "date-fns"
 import { useStaticQuery, graphql } from "gatsby"
 
 import theme from "../theme"
@@ -35,9 +35,9 @@ const MeetupSection = () => {
   } = useStaticQuery(facebookEventQuery)
 
   const upcomingEvents = data.filter(event =>
-    isFuture(new Date(event.start_time))
+    isFuture(parseISO(event.start_time))
   )
-  const pastEvents = data.filter(event => isPast(new Date(event.start_time)))
+  const pastEvents = data.filter(event => isPast(parseISO(event.start_time)))
 
   return (
     <Box pb={[7, 9]}>


### PR DESCRIPTION
## Description
Implement upcoming and past events in meetup section

## Summary of Changes
- disable camelcase and prefer-export-default in eslint
- remove limit in fetching facebook events
- separate meetup event card component

## Screenshots
**With upcoming events**
![Screenshot_2020-04-24 Home ReactJS Philippines](https://user-images.githubusercontent.com/25174423/80217264-fe0e5500-8671-11ea-8eaa-0d65ee26a78f.png)

**Without upcoming events**
![Screenshot_2020-04-24 Home ReactJS Philippines(1)](https://user-images.githubusercontent.com/25174423/80217275-01094580-8672-11ea-90e9-9b00ec1d5592.png)

**Notes**
- To update the meetup section for future events, we just need to rebuild the site.