### PR TITLE
Correct dev board docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ More for information about how you can contribute to this project, check our [co
   | `skills` | String array of your skills/technologies that you would like to promote | <ul><li>Only the first 5 will be listed, but feel free to add as many as you like (We plan to allow devs to be filtered by skills in the future)</li></ul> |
   | `contacts` | Object array of contact information where each item has a `type` and a `url` | <ul><li>`type` can be any of the following: "behance", "email", "github", "linkedin", "twitter", "website"</li><li>`url` must be a URL corresponding to the `type` selected</li></ul> |
 
-3. Open a pull request with your name as the title using the template below. Apply the `dev board` label.
+3. Open a pull request with the title `[DEV BOARD] {YOUR_NAME}` using the template below:
 
   ```
   I have read and verified the following upon opening this pull request to add my information to the ReactJS Philippines Dev Board:


### PR DESCRIPTION
**Description**
- Corrects a step in the dev board docs that instructed contributors to apply a `dev board` label

**Summary of Changes**
- We now indicate that `[DEV BOARD]` should be written in the PR title, instead of indicated through a label

**Screenshots**
![image](https://user-images.githubusercontent.com/7394331/96361369-b3205680-1157-11eb-9bee-48a4021d21c9.png)
