### PR TITLE
Fix mobile responsiveness of images in Dev Boards page.

### DIFF
--- a/content/devs.json
+++ b/content/devs.json
@@ -85,7 +85,7 @@
     "contacts": [
       {
         "type": "website",
-        "url": "http://codekcv.github.io/"
+        "url": "https://codekcv.now.sh/"
       },
       {
         "type": "github",
@@ -107,13 +107,7 @@
     "title": "Frontend Developer",
     "company": "Orange and Crane Innovations, Inc.",
     "blurb": "I'm Jayson. Web and Mobile Developer. Casual Gamer. Hobbyist Cosplayer. Furdaddy.",
-    "skills": [
-      "React",
-      "React-Native",
-      "GraphQL",
-      "NextJS",
-      "GatsbyJS"
-    ],
+    "skills": ["React", "React-Native", "GraphQL", "NextJS", "GatsbyJS"],
     "contacts": [
       {
         "type": "github",

--- a/src/components/devBio.js
+++ b/src/components/devBio.js
@@ -22,8 +22,10 @@ const DevBio = ({
   dev: { avatar, name, title, company, blurb, skills = [], contacts = [] },
 }) => (
   <Flex color="white" flexDirection={["row", "column"]}>
-    <Image width="100%" height="100%" mb={[0, 2]} mr={[2, 0]} src={avatar} />
-    <Box>
+    <Box width={["25%", "100%"]} height="auto" mr={[2, 0]}>
+      <Image width="100%" height="auto" mb={[0, 2]} mr={[2, 0]} src={avatar} />
+    </Box>
+    <Box width={["75%", "100%"]}>
       <Text
         as="p"
         color="lightBlue"

--- a/src/components/devBio.js
+++ b/src/components/devBio.js
@@ -22,9 +22,13 @@ const DevBio = ({
   dev: { avatar, name, title, company, blurb, skills = [], contacts = [] },
 }) => (
   <Flex color="white" flexDirection={["row", "column"]}>
-    <Box width={["25%", "100%"]} height="auto" mr={[2, 0]}>
-      <Image width="100%" height="auto" mb={[0, 2]} mr={[2, 0]} src={avatar} />
-    </Box>
+    <Image
+      width={["25%", "100%"]}
+      height="100%"
+      mb={[0, 2]}
+      mr={[2, 0]}
+      src={avatar}
+    />
     <Box width={["75%", "100%"]}>
       <Text
         as="p"

--- a/src/components/team.js
+++ b/src/components/team.js
@@ -160,7 +160,7 @@ const TeamSection = () => {
       photo: imgChristian?.childImageSharp.fluid.src,
       name: "Christian Villamin",
       role: "Member, Core Team",
-      website: "https://crxnvlmn.github.io/",
+      website: "https://codekcv.now.sh/",
     },
   ]
 


### PR DESCRIPTION
**Description**
- This fixes the inconsistent image size in the mobile version of the dev boards page.

**Summary of Changes**
- In the DevBio component mobile version, the image will take 1/4 and box texts 3/4. This alignment is matched with the first DevBio entry(@galacemiguel's).

**Screenshots**
- Check this video for resizing responsiveness: https://streamable.com/vwkwb6
- Before:
![sc_2020-10-26-040622_374x855](https://user-images.githubusercontent.com/51011835/97117964-2d497000-1742-11eb-8a1d-0bb9282b5736.png)

- After:
![sc_2020-10-26-040628_376x855](https://user-images.githubusercontent.com/51011835/97117958-26226200-1742-11eb-9696-36b7b93e6246.png)
