### PR TITLE
Create CLI to enlist in dev board

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ More for information about how you can contribute to this project, check our [co
 
 ## 📋 Enlisting in the Dev Board
 
+Run `yarn enlist` to enlist using the CLI or create a JSON file by following the steps below.
+
 1. Add a JSON file to the [`content/devs`](https://github.com/reactph/reactjsph-website/blob/master/content/devs) folder with filename `firstname-lastname.json` (all lowercase, separated by `-`), e.g., `juan-dela-cruz.json`.
 
 2. Within that file, define an object describing yourself given the format below. Here's an [example](https://github.com/reactph/reactjsph-website/blob/master/content/devs/franrey-anthony-saycon.json).

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-react-hooks": "^1.7.0",
     "gh-pages": "^2.1.1",
     "husky": "^3.0.4",
+    "inquirer": "^8.2.0",
     "joi": "^17.2.1",
     "lint-staged": "^9.2.3",
     "prettier": "^1.17.1",
@@ -69,7 +70,8 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
     "lint": "eslint \"src/**/*.{js,jsx}\" --fix",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
-    "validate": "lint-staged"
+    "validate": "lint-staged",
+    "enlist": "node scripts/add-dev-board.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/add-dev-board.js
+++ b/scripts/add-dev-board.js
@@ -1,0 +1,213 @@
+/* eslint-disable no-console */
+const inquirer = require("inquirer")
+const { promises: fs } = require("fs")
+const path = require("path")
+
+const CONTACT_TYPES = [
+  "behance",
+  "email",
+  "github",
+  "linkedin",
+  "twitter",
+  "website",
+]
+
+const FIELD_EMPTY_MESSAGE = "Field Required."
+const FIELD_INVALID_URL = "Invalid URL."
+const FIELD_MAX_LENGTH = "Field must be 140 characters or less"
+
+const isFieldEmpty = input => !input?.length
+const isFieldURL = input =>
+  new RegExp(
+    /[(http(s)?)://(www.)?a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/
+  ).test(input)
+const isFieldMaxLength = input => input.length > 140
+
+const askSkills = async (skills = []) => {
+  let newSkills = [...skills]
+  const answers = await inquirer.prompt([
+    {
+      type: "input",
+      name: "skill",
+      message: `Add skill/technology #${newSkills.length + 1}`,
+    },
+  ])
+
+  if (answers.skill?.length) {
+    newSkills = [...newSkills, answers.skill]
+    return askSkills(newSkills)
+  }
+
+  return newSkills
+}
+
+const askContacts = async (contacts = []) => {
+  const { type } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "type",
+      choices: [
+        ...CONTACT_TYPES,
+        `I don't want to add ${contacts?.length ? "another" : "a"} contact`,
+      ],
+      message: `Choose${contacts?.length ? " another" : ""} type`,
+      default: 0,
+    },
+  ])
+
+  if (type.includes("I don't want to add")) {
+    return contacts
+  }
+
+  const { url } = await inquirer.prompt([
+    {
+      type: "input",
+      name: "url",
+      message:
+        "URL (leave empty if you want to cancel adding this contact type)",
+      validate: input => {
+        if (isFieldEmpty(input)) {
+          return true
+        }
+
+        if (!isFieldURL(input)) {
+          return FIELD_INVALID_URL
+        }
+
+        return true
+      },
+    },
+  ])
+
+  if (!url?.length) {
+    return contacts
+  }
+
+  return askContacts([...contacts, { type, url }])
+}
+
+const addToDevBoard = async () => {
+  let data = {}
+
+  const answers = await inquirer.prompt([
+    {
+      type: "input",
+      name: "name",
+      message: "Full Name",
+      validate: input => !isFieldEmpty(input) || FIELD_EMPTY_MESSAGE,
+    },
+    {
+      type: "input",
+      name: "avatar",
+      message:
+        "An external URL to an image of yourself (Must be a square image and less than 80 kB)",
+      validate: input => {
+        if (isFieldEmpty(input)) {
+          return FIELD_EMPTY_MESSAGE
+        }
+
+        if (!isFieldURL(input)) {
+          return FIELD_INVALID_URL
+        }
+
+        return true
+      },
+    },
+    {
+      type: "input",
+      name: "title",
+      message: "Current job title",
+      validate: input => !isFieldEmpty(input) || FIELD_EMPTY_MESSAGE,
+    },
+    {
+      type: "input",
+      name: "company",
+      message: "Your current employer (optional)",
+    },
+    {
+      type: "input",
+      name: "blurb",
+      message: "Short bio describing yourself (140 characters or less)",
+      validate: input => {
+        if (isFieldEmpty(input)) {
+          return FIELD_EMPTY_MESSAGE
+        }
+
+        if (isFieldMaxLength(input)) {
+          return `${FIELD_MAX_LENGTH} (${input.length} chars.)`
+        }
+
+        return true
+      },
+    },
+  ])
+
+  console.log(`
+Add skills/technologies that you would like to promote
+* Only the first 5 will be listed, but feel free to add as many as you like as we plan to allow devs to be filtered by skills in the future
+* Leave blank if you're done adding items
+  `)
+
+  const skills = await askSkills()
+
+  console.log("\nAdd contact information\n")
+
+  const contacts = await askContacts()
+
+  data = {
+    ...answers,
+    skills,
+    contacts: contacts.map(contact => {
+      if (contact.type === "email" && !contact.url.includes("mailto:")) {
+        return {
+          ...contact,
+          url: `mailto:${contact.url}`,
+        }
+      }
+
+      return contact
+    }),
+    company: answers.company?.length ? answers.company : undefined,
+  }
+
+  const fileName = `${answers.name
+    .toLowerCase()
+    .split(".")
+    .join("")
+    .split(" ")
+    .join("-")}.json`
+  const filePath = path.join(__dirname, `../content/devs/${fileName}`)
+  console.log(`\n\nCreating JSON file ${fileName} with content`)
+  console.log(data)
+
+  try {
+    await fs.stat(filePath)
+
+    const { confirm } = await inquirer.prompt([
+      {
+        name: "confirm",
+        type: "confirm",
+        message: `A file with name ${fileName} already exists. Do you want to overwrite this file?`,
+        default: false,
+      },
+    ])
+
+    if (confirm) {
+      await fs.unlink(filePath)
+    }
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      console.error(err)
+      return
+    }
+  }
+
+  try {
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2))
+    console.log(`${answers.name} successfully added to the Dev Board`)
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+addToDevBoard()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,7 +3548,7 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
-bl@^4.0.0:
+bl@^4.0.0, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
@@ -4108,7 +4108,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.0:
+chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -4271,6 +4271,11 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-spinners@^2.5.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
+  integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
+
 cli-truncate@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
@@ -4283,6 +4288,11 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 clipboardy@^2.3.0:
   version "2.3.0"
@@ -4326,6 +4336,11 @@ clone-response@1.0.2, clone-response@^1.0.2:
   integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
   dependencies:
     mimic-response "^1.0.0"
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
 coa@^2.0.2:
   version "2.0.2"
@@ -5234,6 +5249,13 @@ default-gateway@^4.2.0:
   dependencies:
     execa "^1.0.0"
     ip-regex "^2.1.0"
+
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  dependencies:
+    clone "^1.0.2"
 
 defer-to-connect@^1.0.1:
   version "1.1.3"
@@ -8891,6 +8913,26 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+inquirer@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.0.tgz#f44f008dd344bbfc4b30031f45d984e034a3ac3a"
+  integrity sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.2.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
 internal-ip@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"
@@ -9226,6 +9268,11 @@ is-installed-globally@^0.4.0:
     global-dirs "^3.0.0"
     is-path-inside "^3.0.2"
 
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
 is-invalid-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-invalid-path/-/is-invalid-path-0.1.0.tgz#307a855b3cf1a938b44ea70d2c61106053714f34"
@@ -9475,6 +9522,11 @@ is-unc-path@^1.0.0:
   integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
   dependencies:
     unc-path-regex "^0.1.2"
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-url@^1.2.4:
   version "1.2.4"
@@ -10200,6 +10252,14 @@ log-symbols@^3.0.0:
   integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
   dependencies:
     chalk "^2.4.2"
+
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
 
 log-update@^2.3.0:
   version "2.3.0"
@@ -11586,6 +11646,21 @@ optionator@^0.8.1, optionator@^0.8.2, optionator@^0.8.3:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
+
+ora@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
 
 original@>=0.0.5, original@^1.0.0:
   version "1.0.2"
@@ -13851,6 +13926,13 @@ rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.2, rxjs@^6.5.3:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.2.0:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.4.tgz#3d6bd407e6b7ce9a123e76b1e770dc5761aa368d"
+  integrity sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -15431,7 +15513,7 @@ tslib@^1.0.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^2, tslib@^2.0.3, tslib@~2.3.0:
+tslib@^2, tslib@^2.0.3, tslib@^2.1.0, tslib@~2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -16069,6 +16151,13 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
+
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
+  dependencies:
+    defaults "^1.0.3"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
**Description**
- Create CLI for enlisting in the dev board

**Summary of Changes**
- Added inquirer library
- Added add-dev-board.js to scripts folder which contains the CLI script
- Updated package.json scripts to add script that opens the CLI to enlist

**How to Test**
- On the root folder, run `yarn enlist`. This should show a series of prompts that asks the user about the data needed for the dev board.
- Once filled up, a JSON file must be created in the appropriate location.
